### PR TITLE
Add permissions nodes

### DIFF
--- a/src/main/java/fr/aeldit/cyan/CyanClientCore.java
+++ b/src/main/java/fr/aeldit/cyan/CyanClientCore.java
@@ -2,6 +2,7 @@ package fr.aeldit.cyan;
 
 import fr.aeldit.cyan.commands.LocationCommands;
 import fr.aeldit.cyan.commands.MiscellaneousCommands;
+import fr.aeldit.cyan.commands.PermissionsCommands;
 import fr.aeldit.cyan.commands.TeleportationCommands;
 import fr.aeldit.cyan.teleportation.TPa;
 import fr.aeldit.cyanlib.lib.commands.CyanLibConfigCommands;
@@ -51,6 +52,7 @@ public class CyanClientCore implements ClientModInitializer
                     TeleportationCommands.register(dispatcher);
                     MiscellaneousCommands.register(dispatcher);
                     LocationCommands.register(dispatcher);
+                    PermissionsCommands.register(dispatcher);
                 }
         );
         CYAN_LOGGER.info("[Cyan] Successfully initialized");

--- a/src/main/java/fr/aeldit/cyan/CyanServerCore.java
+++ b/src/main/java/fr/aeldit/cyan/CyanServerCore.java
@@ -2,6 +2,7 @@ package fr.aeldit.cyan;
 
 import fr.aeldit.cyan.commands.LocationCommands;
 import fr.aeldit.cyan.commands.MiscellaneousCommands;
+import fr.aeldit.cyan.commands.PermissionsCommands;
 import fr.aeldit.cyan.commands.TeleportationCommands;
 import fr.aeldit.cyan.teleportation.TPa;
 import fr.aeldit.cyanlib.lib.commands.CyanLibConfigCommands;
@@ -49,6 +50,7 @@ public class CyanServerCore implements DedicatedServerModInitializer
                     TeleportationCommands.register(dispatcher);
                     MiscellaneousCommands.register(dispatcher);
                     LocationCommands.register(dispatcher);
+                    PermissionsCommands.register(dispatcher);
                 }
         );
         CYAN_LOGGER.info("[Cyan] Successfully initialized");

--- a/src/main/java/fr/aeldit/cyan/commands/Commons.java
+++ b/src/main/java/fr/aeldit/cyan/commands/Commons.java
@@ -1,0 +1,56 @@
+package fr.aeldit.cyan.commands;
+
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static fr.aeldit.cyan.CyanCore.CYAN_LANG_UTILS;
+
+public class Commons
+{
+    public static @Nullable BlockPos bed(@NotNull ServerPlayerEntity player)
+    {
+        BlockPos spawnPos = player.getSpawnPointPosition();
+        MinecraftServer server = player.getServer();
+        if (spawnPos == null || server == null)
+        {
+            CYAN_LANG_UTILS.sendPlayerMessage(player, "error.bedNotFound");
+            return null;
+        }
+
+        RegistryKey<World> spawnDim = player.getSpawnPointDimension();
+
+        player.teleport(
+                server.getWorld(spawnDim),
+                spawnPos.getX(),
+                spawnPos.getY(),
+                spawnPos.getZ(),
+                player.getYaw(), player.getPitch()
+        );
+
+        String key = spawnDim == World.OVERWORLD ? "bed" : "respawnAnchor";
+        CYAN_LANG_UTILS.sendPlayerMessage(player, "msg.%s".formatted(key));
+        return spawnPos;
+    }
+
+    public static double surface(@NotNull ServerPlayerEntity player)
+    {
+        BlockPos blockPos = player.getBlockPos();
+        double topY = player.getWorld().getTopY(Heightmap.Type.WORLD_SURFACE, blockPos.getX(), blockPos.getZ());
+
+        player.teleport(
+                player.getServerWorld(),
+                blockPos.getX(),
+                topY,
+                blockPos.getZ(),
+                player.getYaw(), player.getPitch()
+        );
+        CYAN_LANG_UTILS.sendPlayerMessage(player, "msg.surface");
+        return topY;
+    }
+}

--- a/src/main/java/fr/aeldit/cyan/commands/LocationCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/LocationCommands.java
@@ -11,7 +11,6 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -241,21 +240,7 @@ public class LocationCommands
             return 0;
         }
 
-        switch (loc.getDimension())
-        {
-            case "overworld" -> player.teleport(
-                    server.getWorld(World.OVERWORLD), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(),
-                    loc.getPitch()
-            );
-            case "nether" -> player.teleport(
-                    server.getWorld(World.NETHER), loc.getX(), loc.getY(), loc.getZ(), loc.getYaw(),
-                    loc.getPitch()
-            );
-            case "end" -> player.teleport(
-                    server.getWorld(World.END), loc.getX(), loc.getY(), loc.getZ(),
-                    loc.getYaw(), loc.getPitch()
-            );
-        }
+        loc.teleport(player, server);
 
         CYAN_LANG_UTILS.sendPlayerMessage(player, "msg.goToLocation", Formatting.YELLOW + locationName);
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
@@ -4,12 +4,15 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
 import java.util.List;
 
 public class PermissionsCommands
@@ -28,15 +31,35 @@ public class PermissionsCommands
                                         .then(CommandManager.argument("targets", EntityArgumentType.players())
                                                       .suggests((context, builder) -> CommandSource.suggestMatching(
                                                               context.getSource().getPlayerNames(), builder
-                                                      )).executes(PermissionsCommands::executeForSelector)
+                                                      )).executes(PermissionsCommands::executeForTargets)
                                         )
                         )
                 )
         );
     }
 
-    public static int executeForSelector(@NotNull CommandContext<ServerCommandSource> context)
+    public static int executeForTargets(
+            @NotNull CommandContext<ServerCommandSource> context
+    ) throws CommandSyntaxException
     {
+        String command = StringArgumentType.getString(context, "command");
+        if (!COMMANDS.contains(command))
+        {
+            return 0;
+        }
+
+        Collection<ServerPlayerEntity> players = EntityArgumentType.getPlayers(context, "targets");
+        if (players.isEmpty())
+        {
+            return 0;
+        }
+
+        switch (command)
+        {
+            case "bed" -> TeleportationCommands.bedForTargets(players);
+            case "surface" -> TeleportationCommands.surfaceForTargets(players);
+        }
+
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
@@ -1,0 +1,36 @@
+package fr.aeldit.cyan.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class PermissionsCommands
+{
+    private static final List<String> COMMANDS = List.of("bed", "surface");
+
+    public static void register(@NotNull CommandDispatcher<ServerCommandSource> dispatcher)
+    {
+        dispatcher.register(
+                CommandManager.literal("cyan").then(
+                        CommandManager.literal("execute").then(
+                                CommandManager.argument("command", StringArgumentType.string())
+                                        .suggests((context, builder) -> CommandSource.suggestMatching(
+                                                COMMANDS, builder
+                                        ))
+                        )
+                ).executes(PermissionsCommands::executeForSelector)
+        );
+    }
+
+    public static int executeForSelector(@NotNull CommandContext<ServerCommandSource> context)
+    {
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
@@ -67,8 +67,8 @@ public class PermissionsCommands
 
         switch (command)
         {
-            case "bed" -> TeleportationCommands.bedForTargets(players);
-            case "surface" -> TeleportationCommands.surfaceForTargets(players);
+            case "bed" -> players.forEach(Commons::bed);
+            case "surface" -> players.forEach(Commons::surface);
         }
 
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.command.CommandSource;
+import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import org.jetbrains.annotations.NotNull;
@@ -24,8 +25,13 @@ public class PermissionsCommands
                                         .suggests((context, builder) -> CommandSource.suggestMatching(
                                                 COMMANDS, builder
                                         ))
+                                        .then(CommandManager.argument("targets", EntityArgumentType.players())
+                                                      .suggests((context, builder) -> CommandSource.suggestMatching(
+                                                              context.getSource().getPlayerNames(), builder
+                                                      )).executes(PermissionsCommands::executeForSelector)
+                                        )
                         )
-                ).executes(PermissionsCommands::executeForSelector)
+                )
         );
     }
 

--- a/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/PermissionsCommands.java
@@ -15,6 +15,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.List;
 
+import static fr.aeldit.cyan.CyanCore.CYAN_LIB_UTILS;
+import static fr.aeldit.cyan.config.CyanLibConfigImpl.MIN_OP_LVL_PERM_NODES;
+
 public class PermissionsCommands
 {
     private static final List<String> COMMANDS = List.of("bed", "surface");
@@ -42,6 +45,14 @@ public class PermissionsCommands
             @NotNull CommandContext<ServerCommandSource> context
     ) throws CommandSyntaxException
     {
+        ServerPlayerEntity playerSource = context.getSource().getPlayer();
+        // If the command source is the not server's console (playerSource == null)
+        // and the player doesn't have the required permission
+        if (playerSource != null && !CYAN_LIB_UTILS.hasPermission(playerSource, MIN_OP_LVL_PERM_NODES.getValue()))
+        {
+            return 0;
+        }
+
         String command = StringArgumentType.getString(context, "command");
         if (!COMMANDS.contains(command))
         {

--- a/src/main/java/fr/aeldit/cyan/commands/TeleportationCommands.java
+++ b/src/main/java/fr/aeldit/cyan/commands/TeleportationCommands.java
@@ -21,6 +21,8 @@ import net.minecraft.world.Heightmap;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 import static fr.aeldit.cyan.CyanCore.*;
 import static fr.aeldit.cyan.config.CyanLibConfigImpl.*;
 import static fr.aeldit.cyan.teleportation.TPa.addPlayerToQueue;
@@ -174,6 +176,33 @@ public class TeleportationCommands
         return Command.SINGLE_SUCCESS;
     }
 
+    public static void bedForTargets(@NotNull Collection<ServerPlayerEntity> players)
+    {
+        for (ServerPlayerEntity player : players)
+        {
+            BlockPos spawnPos = player.getSpawnPointPosition();
+            MinecraftServer server = player.getServer();
+
+            if (spawnPos == null || server == null)
+            {
+                return;
+            }
+
+            RegistryKey<World> spawnDim = player.getSpawnPointDimension();
+
+            player.teleport(
+                    server.getWorld(spawnDim),
+                    spawnPos.getX(),
+                    spawnPos.getY(),
+                    spawnPos.getZ(),
+                    player.getYaw(), player.getPitch()
+            );
+
+            String key = spawnDim == World.OVERWORLD ? "bed" : "respawnAnchor";
+            CYAN_LANG_UTILS.sendPlayerMessage(player, "msg.%s".formatted(key));
+        }
+    }
+
     /**
      * Called when a player execute the commands {@code /surface} or {@code /s}
      * <p>
@@ -250,6 +279,27 @@ public class TeleportationCommands
             player.addExperienceLevels(-1 * requiredXpLevel);
         }
         return Command.SINGLE_SUCCESS;
+    }
+
+    public static void surfaceForTargets(@NotNull Collection<ServerPlayerEntity> players)
+    {
+        for (ServerPlayerEntity player : players)
+        {
+            BlockPos blockPos = player.getBlockPos();
+            double topY = player.getWorld().getTopY(Heightmap.Type.WORLD_SURFACE, blockPos.getX(), blockPos.getZ());
+
+            player.teleport(
+                    player.getServerWorld(),
+                    blockPos.getX(),
+                    topY,
+                    blockPos.getZ(),
+                    player.getYaw(), player.getPitch()
+            );
+            CYAN_LANG_UTILS.sendPlayerMessage(
+                    player,
+                    "msg.surface"
+            );
+        }
     }
 
     public static int tpa(@NotNull CommandContext<ServerCommandSource> context)

--- a/src/main/java/fr/aeldit/cyan/commands/arguments/ArgumentSuggestion.java
+++ b/src/main/java/fr/aeldit/cyan/commands/arguments/ArgumentSuggestion.java
@@ -1,5 +1,6 @@
 package fr.aeldit.cyan.commands.arguments;
 
+import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import fr.aeldit.cyan.teleportation.TPa;
@@ -9,8 +10,11 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import static fr.aeldit.cyan.CyanCore.LOCATIONS;
 
 public final class ArgumentSuggestion
 {
@@ -47,5 +51,25 @@ public final class ArgumentSuggestion
             return new CompletableFuture<>();
         }
         return CommandSource.suggestMatching(requestingPlayers, builder);
+    }
+
+    public static CompletableFuture<Suggestions> getPlayerTargets(
+            @NotNull CommandContext<ServerCommandSource> context, @NotNull SuggestionsBuilder builder
+    )
+    {
+        Collection<String> players = context.getSource().getPlayerNames();
+        ArrayList<String> targets = new ArrayList<>(players.size() + 1);
+        targets.addAll(players);
+        targets.add("@a");
+        return CommandSource.suggestMatching(targets, builder);
+    }
+
+    public static CompletableFuture<Suggestions> getLocationsIfLoc(
+            @NotNull CommandContext<ServerCommandSource> context, @NotNull SuggestionsBuilder builder
+    )
+    {
+        return context.getInput().split(" ")[2].equals("location")
+               ? LOCATIONS.getLocationsNames(builder)
+               : new CompletableFuture<>();
     }
 }

--- a/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
+++ b/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
@@ -112,6 +112,7 @@ public class CyanLibConfigImpl implements ICyanLibConfig
                 entry("msg.set.distanceToEntitiesKgi", "§3The distance for §d/kgi §3is now %s"),
                 entry("msg.set.minOpLvlKgi", "§3The minimum OP level to execute §d/kgi §3is now %s"),
                 entry("msg.set.minOpLvlEditLocation", "§3The minimum OP level to edit locations is now %s"),
+                entry("msg.set.minOpLvlPermNodes", "§3The minimum OP level to use permission nodes is now %s"),
                 entry("msg.set.daysToRemoveBackTp", "§3The number of days to keep the last death locations is now %s"),
                 entry("msg.set.useXpToTeleport", "§3Toggled the use of XP to teleport %s"),
                 entry(
@@ -166,6 +167,11 @@ public class CyanLibConfigImpl implements ICyanLibConfig
                                 "minimum OP level required to edit locations"
                 ),
                 entry(
+                        "msg.getDesc.minOpLvlPermNodes",
+                        "§3The §eminOpLvlPermNodes §3determines the " +
+                                "minimum OP level required to use the permission nodes"
+                ),
+                entry(
                         "msg.getDesc.daysToRemoveBackTp",
                         "§3The§e daysToRemoveBackTp §3option defines the " +
                                 "number of days the last death location of a player is kept)"
@@ -207,6 +213,7 @@ public class CyanLibConfigImpl implements ICyanLibConfig
                 entry("msg.getCfg.distanceToEntitiesKgi", "§6- §d/kgi §3distance (in chunks) : %s"),
                 entry("msg.getCfg.minOpLvlKgi", "§6- §3Minimum OP level for §d/kgi §3: %s"),
                 entry("msg.getCfg.minOpLvlEditLocation", "§6- §3Minimum OP level to edit locations: %s"),
+                entry("msg.getCfg.minOpLvlPermNodes", "§6- §3Minimum OP level to use permission nodes: %s"),
                 entry("msg.getCfg.daysToRemoveBackTp", "§6- §3Days to keep the death location: %s"),
                 entry("msg.getCfg.useXpToTeleport", "§6- §3Use XP for teleportation commands: %s"),
                 entry("msg.getCfg.xpUsePoints", "§6- §3Use XP points instead of XP levels : %s"),

--- a/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
+++ b/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
@@ -11,6 +11,7 @@ import static java.util.Map.entry;
 
 public class CyanLibConfigImpl implements ICyanLibConfig
 {
+    // Allows
     public static final BooleanOption ALLOW_BED = new BooleanOption("allowBed", true);
     public static final BooleanOption ALLOW_KGI = new BooleanOption("allowKgi", true);
     public static final BooleanOption ALLOW_SURFACE = new BooleanOption("allowSurface", true);
@@ -18,9 +19,12 @@ public class CyanLibConfigImpl implements ICyanLibConfig
     public static final BooleanOption ALLOW_BACK_TP = new BooleanOption("allowBackTp", true);
     public static final BooleanOption ALLOW_TPA = new BooleanOption("allowTpa", true);
 
+    // Min OP Level
     public static final IntegerOption MIN_OP_LVL_KGI = new IntegerOption("minOpLvlKgi", 4, RULES.OP_LEVELS);
     public static final IntegerOption MIN_OP_LVL_EDIT_LOCATIONS = new IntegerOption(
             "minOpLvlEditLocation", 4, RULES.OP_LEVELS);
+
+    // Other
     public static final IntegerOption DISTANCE_TO_ENTITIES_KGI = new IntegerOption(
             "distanceToEntitiesKgi", 12, RULES.POSITIVE_VALUE
     );
@@ -28,6 +32,7 @@ public class CyanLibConfigImpl implements ICyanLibConfig
             "daysToRemoveBackTp", 180, RULES.POSITIVE_VALUE
     );
 
+    // XP to teleport
     public static final BooleanOption USE_XP_TO_TELEPORT = new BooleanOption(
             "useXpToTeleport", true
     );

--- a/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
+++ b/src/main/java/fr/aeldit/cyan/config/CyanLibConfigImpl.java
@@ -22,7 +22,11 @@ public class CyanLibConfigImpl implements ICyanLibConfig
     // Min OP Level
     public static final IntegerOption MIN_OP_LVL_KGI = new IntegerOption("minOpLvlKgi", 4, RULES.OP_LEVELS);
     public static final IntegerOption MIN_OP_LVL_EDIT_LOCATIONS = new IntegerOption(
-            "minOpLvlEditLocation", 4, RULES.OP_LEVELS);
+            "minOpLvlEditLocation", 4, RULES.OP_LEVELS
+    );
+    public static final IntegerOption MIN_OP_LVL_PERM_NODES = new IntegerOption(
+            "minOpLvlPermNodes", 4, RULES.OP_LEVELS
+    );
 
     // Other
     public static final IntegerOption DISTANCE_TO_ENTITIES_KGI = new IntegerOption(

--- a/src/main/java/fr/aeldit/cyan/teleportation/Locations.java
+++ b/src/main/java/fr/aeldit/cyan/teleportation/Locations.java
@@ -62,8 +62,13 @@ public class Locations
             return dimension;
         }
 
-        public void teleport(ServerPlayerEntity player, MinecraftServer server)
+        public void teleport(ServerPlayerEntity player, @Nullable MinecraftServer server)
         {
+            if (server == null)
+            {
+                return;
+            }
+
             switch (dimension)
             {
                 case "overworld" -> player.teleport(server.getWorld(World.OVERWORLD), x, y, z, yaw, pitch);

--- a/src/main/java/fr/aeldit/cyan/teleportation/Locations.java
+++ b/src/main/java/fr/aeldit/cyan/teleportation/Locations.java
@@ -7,6 +7,9 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandSource;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -59,29 +62,14 @@ public class Locations
             return dimension;
         }
 
-        public double getX()
+        public void teleport(ServerPlayerEntity player, MinecraftServer server)
         {
-            return x;
-        }
-
-        public double getY()
-        {
-            return y;
-        }
-
-        public double getZ()
-        {
-            return z;
-        }
-
-        public float getYaw()
-        {
-            return yaw;
-        }
-
-        public float getPitch()
-        {
-            return pitch;
+            switch (dimension)
+            {
+                case "overworld" -> player.teleport(server.getWorld(World.OVERWORLD), x, y, z, yaw, pitch);
+                case "nether" -> player.teleport(server.getWorld(World.NETHER), x, y, z, yaw, pitch);
+                case "end" -> player.teleport(server.getWorld(World.END), x, y, z, yaw, pitch);
+            }
         }
     }
 


### PR DESCRIPTION
Add a way for server moderators to execute a given command for a selected set of players or using a selector (`@a`, `@e`, ...).

The moderators will be able to do so directly from Minecraft if they have the required OP permission, or using the server's console